### PR TITLE
global: new package to manage global properties to a builder

### DIFF
--- a/builder/copy.go
+++ b/builder/copy.go
@@ -138,7 +138,7 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 		}
 	}
 
-	fn, cacheKey, err := tar.Archive(b.config.Context, rel, target, ignoreList, b.Logger)
+	fn, cacheKey, err := tar.Archive(b.config.Context, rel, target, ignoreList, b.config.Globals.Logger)
 	if err != nil {
 		return nil, createException(m, err.Error())
 	}
@@ -146,15 +146,13 @@ func doCopy(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, s
 
 	cacheKey = fmt.Sprintf("box:copy %s", cacheKey)
 
-	if b.exec.Image().GetCache() {
-		cached, err := b.exec.Image().CheckCache(cacheKey)
-		if err != nil {
-			return nil, createException(m, err.Error())
-		}
+	cached, err := b.exec.Image().CheckCache(cacheKey)
+	if err != nil {
+		return nil, createException(m, err.Error())
+	}
 
-		if cached {
-			return nil, nil
-		}
+	if cached {
+		return nil, nil
 	}
 
 	f, err := os.Open(fn)

--- a/builder/executor/docker/docker_run_test.go
+++ b/builder/executor/docker/docker_run_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"errors"
 
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/logger"
 
 	. "gopkg.in/check.v1"
+)
+
+var (
+	runGlobals = &global.Global{Logger: logger.New("", false), ShowRun: true}
 )
 
 func (ds *dockerSuite) TestRunCommit(c *C) {
@@ -18,14 +23,14 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 		return "", errors.New("an error")
 	}
 
-	d, err := NewDocker(context.Background(), logger.New("", false), true, false, false)
+	d, err := NewDocker(context.Background(), runGlobals)
 	c.Assert(err, IsNil)
 	id, err := d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
 	c.Assert(d.Commit("", commit), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), logger.New("", false), true, false, false)
+	d, err = NewDocker(context.Background(), runGlobals)
 	c.Assert(err, IsNil)
 	id, err = d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
@@ -34,7 +39,7 @@ func (ds *dockerSuite) TestRunCommit(c *C) {
 }
 
 func (ds *dockerSuite) TestRunHook(c *C) {
-	d, err := NewDocker(context.Background(), logger.New("", false), true, false, false)
+	d, err := NewDocker(context.Background(), runGlobals)
 	c.Assert(err, IsNil)
 	id, err := d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)
@@ -44,7 +49,7 @@ func (ds *dockerSuite) TestRunHook(c *C) {
 	c.Assert(d.Commit("test", d.RunHook), IsNil)
 	c.Assert(d.config.Image, Not(Equals), id)
 
-	d, err = NewDocker(context.Background(), logger.New("", false), true, false, false)
+	d, err = NewDocker(context.Background(), runGlobals)
 	c.Assert(err, IsNil)
 	id, err = d.Layers().Fetch(d.config, "debian:latest")
 	c.Assert(err, IsNil)

--- a/builder/executor/docker/run.go
+++ b/builder/executor/docker/run.go
@@ -30,12 +30,12 @@ func (d *Docker) handleRunError(ctx context.Context, id string, errChan chan err
 	select {
 	case <-ctx.Done():
 		if ctx.Err() != nil {
-			d.logger.Error(ctx.Err())
+			d.globals.Logger.Error(ctx.Err())
 		}
 		d.Destroy(id)
 	case err, ok := <-errChan:
 		if ok {
-			d.logger.Error(err)
+			d.globals.Logger.Error(err)
 			d.Destroy(id)
 		}
 	}
@@ -106,16 +106,16 @@ func (d *Docker) startAndWait(ctx context.Context, id string, reader io.Reader, 
 
 	var writer io.Writer = os.Stdout
 
-	if !d.stdin && d.showRun {
-		d.logger.BeginOutput()
-		defer d.logger.EndOutput()
+	if !d.stdin && d.globals.ShowRun {
+		d.globals.Logger.BeginOutput()
+		defer d.globals.Logger.EndOutput()
 	}
 
-	if !d.showRun {
+	if !d.globals.ShowRun {
 		writer = bytes.NewBuffer([]byte{})
 	}
 
-	if !d.tty {
+	if !d.globals.TTY {
 		go func() {
 			// docker mux's the streams, and requires this stdcopy library to unpack them.
 			_, err = stdcopy.StdCopy(writer, writer, reader)

--- a/builder/executor/executor.go
+++ b/builder/executor/executor.go
@@ -51,15 +51,6 @@ type Executor interface {
 	// facilitate debugging.
 	SetStdin(bool)
 
-	// UseTTY determines whether or not to allow docker to use a TTY for both run and pull operations.
-	UseTTY(bool)
-
-	// ShowRun toggles the visibility of run output.
-	ShowRun(bool)
-
-	// GetShowRun returns the visibility of run output.
-	GetShowRun() bool
-
 	// Layers returns the layer handler for this executor.
 	Layers() layers.Layers
 

--- a/builder/util_test.go
+++ b/builder/util_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/box-builder/box/global"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
@@ -16,10 +17,12 @@ import (
 
 func runBuilder(script string) (*Builder, error) {
 	b, err := NewBuilder(BuildConfig{
+		Globals: &global.Global{
+			Cache:   os.Getenv("NO_CACHE") == "",
+			ShowRun: true,
+		},
 		Context: context.Background(),
 		Runner:  make(chan struct{}),
-		Cache:   os.Getenv("NO_CACHE") == "",
-		ShowRun: true,
 	})
 	if err != nil {
 		return nil, err

--- a/builder/verbs.go
+++ b/builder/verbs.go
@@ -196,7 +196,7 @@ func flatten(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, 
 	defer signal.Handler.RemoveFile(f.Name())
 
 	defer os.Remove(f.Name())
-	if err := copy.WithProgress(f, rc, b.Logger, "Downloading image contents to host"); err != nil && err != io.EOF {
+	if err := copy.WithProgress(f, rc, b.config.Globals.Logger, "Downloading image contents to host"); err != nil && err != io.EOF {
 		f.Close()
 		return nil, createException(m, err.Error())
 	}
@@ -213,7 +213,7 @@ func flatten(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, 
 		return nil, createException(m, err.Error())
 	}
 
-	fmt.Printf("%s%s\n", b.Logger.Plan(), b.Logger.Notice(fmt.Sprintf("Flattened Image: %s", strings.SplitN(b.exec.Config().Image, ":", 2)[1][:12])))
+	fmt.Printf("%s%s\n", b.config.Globals.Logger.Plan(), b.config.Globals.Logger.Notice(fmt.Sprintf("Flattened Image: %s", strings.SplitN(b.exec.Config().Image, ":", 2)[1][:12])))
 	return nil, nil
 }
 
@@ -233,7 +233,7 @@ func tag(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self
 		return nil, createException(m, err.Error())
 	}
 
-	b.Logger.Tag(name)
+	b.config.Globals.Logger.Tag(name)
 
 	return nil, nil
 }
@@ -327,7 +327,7 @@ func run(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self
 		return nil, createException(m, "no command to run in run statement")
 	}
 
-	runState := b.exec.GetShowRun()
+	runState := b.config.Globals.ShowRun
 	output := runState
 
 	if output {
@@ -349,13 +349,13 @@ func run(b *Builder, cacheKey string, args []*mruby.MrbValue, m *mruby.Mrb, self
 	}
 
 	b.exec.Config().TemporaryCommand([]string{"/bin/sh", "-c"}, []string{args[0].String()})
-	b.exec.ShowRun(output)
+	b.config.Globals.ShowRun = output
 
 	if err := b.exec.Commit(cacheKey, b.exec.RunHook); err != nil {
 		return nil, createException(m, err.Error())
 	}
 
-	b.exec.ShowRun(runState)
+	b.config.Globals.ShowRun = runState
 
 	return nil, nil
 }

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -7,14 +7,14 @@ import (
 	"io/ioutil"
 
 	"github.com/box-builder/box/builder/config"
-	"github.com/box-builder/box/logger"
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/pull"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 )
 
 // Docker does stuff
-func Docker(context context.Context, logger *logger.Logger, client *client.Client, tty bool, config *config.Config, name string) (string, []string, error) {
+func Docker(context context.Context, globals *global.Global, client *client.Client, config *config.Config, name string) (string, []string, error) {
 	inspect, _, err := client.ImageInspectWithRaw(context, name)
 	if err != nil {
 		reader, err := client.ImagePull(context, name, types.ImagePullOptions{})
@@ -22,16 +22,16 @@ func Docker(context context.Context, logger *logger.Logger, client *client.Clien
 			return "", nil, err
 		}
 
-		if !tty {
-			logger.Print(fmt.Sprintf("Pulling %q... ", name))
+		if !globals.TTY {
+			globals.Logger.Print(fmt.Sprintf("Pulling %q... ", name))
 
 			if _, err := io.Copy(ioutil.Discard, reader); err != io.EOF && err != nil {
 				return "", nil, err
 			}
 
-			fmt.Fprintln(logger.Output(), "done.")
+			fmt.Fprintln(globals.Logger.Output(), "done.")
 		} else {
-			pull.NewProgress(tty, reader).Process()
+			pull.NewProgress(globals.TTY, reader).Process()
 		}
 
 		select {

--- a/global/global.go
+++ b/global/global.go
@@ -1,0 +1,12 @@
+package global
+
+import "github.com/box-builder/box/logger"
+
+// Global represents global variables for the processing of an entire box run.
+type Global struct {
+	Cache     bool
+	TTY       bool // controls terminal codes
+	ShowRun   bool
+	OmitFuncs []string
+	Logger    *logger.Logger
+}

--- a/layers/docker_test.go
+++ b/layers/docker_test.go
@@ -12,6 +12,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/box-builder/box/builder/config"
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/image"
 	"github.com/box-builder/box/logger"
 	"github.com/docker/docker/api/types"
@@ -64,7 +65,7 @@ func (ds *dockerSuite) TearDownSuite(c *C) {
 func (ds *dockerSuite) TestLookup(c *C) {
 	imageName := "alpine"
 
-	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
+	d, err := NewDocker(context.Background(), &global.Global{TTY: ds.tty, Logger: logger.New("", false)})
 	c.Assert(err, IsNil)
 
 	// XXX ok if this call fails
@@ -86,7 +87,7 @@ func (ds *dockerSuite) TestLookup(c *C) {
 func (ds *dockerSuite) TestMakeImage(c *C) {
 	imageName := "postgres"
 
-	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
+	d, err := NewDocker(context.Background(), &global.Global{TTY: ds.tty, Logger: logger.New("", false)})
 	c.Assert(err, IsNil)
 
 	_, err = d.Fetch(ds.config, imageName)
@@ -174,7 +175,7 @@ func (ds *dockerSuite) TestMakeImage(c *C) {
 }
 
 func (ds *dockerSuite) TestFetch(c *C) {
-	d, err := NewDocker(context.Background(), ds.tty, logger.New("", false))
+	d, err := NewDocker(context.Background(), &global.Global{TTY: ds.tty, Logger: logger.New("", false)})
 	c.Assert(err, IsNil)
 
 	id, err := d.Fetch(ds.config, "debian:latest")

--- a/layers/types.go
+++ b/layers/types.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/box-builder/box/builder/config"
-	"github.com/box-builder/box/logger"
+	"github.com/box-builder/box/global"
 )
 
 // Image needs a description
@@ -23,12 +23,6 @@ type Image interface {
 
 	// CheckCache consults the cache to see if there are any items which fit it.
 	CheckCache(string) (bool, error)
-
-	// UseCache determines if the cache should be considered or not.
-	UseCache(bool)
-
-	// GetCache gets the current value of whether or not to use the cache
-	GetCache() bool
 
 	// ImageID returns the image identifier of the most recent layer.
 	ImageID() string
@@ -68,8 +62,7 @@ type Layers interface {
 
 // ImageConfig sets the properties used to construct an
 type ImageConfig struct {
-	Layers   Layers
-	UseCache bool
-	Config   *config.Config
-	Logger   *logger.Logger
+	Layers  Layers
+	Config  *config.Config
+	Globals *global.Global
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/box-builder/box/builder"
 	"github.com/box-builder/box/copy"
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/logger"
 	"github.com/box-builder/box/multi"
 	"github.com/box-builder/box/repl"
@@ -127,14 +128,16 @@ func main() {
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		runChan := make(chan struct{})
 		buildConfig := builder.BuildConfig{
-			ShowRun:   true,
-			TTY:       tty,
-			OmitFuncs: ctx.GlobalStringSlice("omit"),
-			Cache:     getCache(ctx),
-			Context:   cancelCtx,
-			Runner:    runChan,
-			FileName:  args[0],
-			Logger:    logger.New(args[0], notrim),
+			Globals: &global.Global{
+				ShowRun:   true,
+				TTY:       tty,
+				OmitFuncs: ctx.GlobalStringSlice("omit"),
+				Cache:     getCache(ctx),
+				Logger:    logger.New(args[0], notrim),
+			},
+			Context:  cancelCtx,
+			Runner:   runChan,
+			FileName: args[0],
 		}
 
 		b, err := mkBuilder(cancel, buildConfig)
@@ -197,14 +200,16 @@ func runMulti(ctx *cli.Context) {
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		runChan := make(chan struct{})
 		buildConfig := builder.BuildConfig{
-			ShowRun:   false,
-			TTY:       true,
-			OmitFuncs: append(ctx.StringSlice("omit"), "debug"),
-			Cache:     getCache(ctx),
-			Context:   cancelCtx,
-			Runner:    runChan,
-			FileName:  filename,
-			Logger:    logger.New(filename, notrim),
+			Globals: &global.Global{
+				ShowRun:   false,
+				TTY:       true,
+				OmitFuncs: append(ctx.StringSlice("omit"), "debug"),
+				Cache:     getCache(ctx),
+				Logger:    logger.New(filename, notrim),
+			},
+			Context:  cancelCtx,
+			Runner:   runChan,
+			FileName: filename,
 		}
 		signal.Handler.AddFunc(cancel)
 		signal.Handler.AddRunner(runChan)

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -11,6 +11,7 @@ import (
 	. "testing"
 
 	"github.com/box-builder/box/builder"
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/logger"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -126,11 +127,13 @@ func mkBuilders(plans map[int]string) []*builder.Builder {
 		l.Record()
 
 		b, err := builder.NewBuilder(builder.BuildConfig{
+			Globals: &global.Global{
+				Logger: l,
+				Cache:  os.Getenv("NO_CACHE") == "",
+			},
 			Context:  context.Background(),
 			Runner:   make(chan struct{}),
-			Cache:    os.Getenv("NO_CACHE") == "",
 			FileName: mkPlanDir(dir, i),
-			Logger:   l,
 		})
 
 		if err != nil {
@@ -214,7 +217,7 @@ func (ms *multiSuite) TestMultiFrom(c *C) {
 	var found bool
 
 	for _, b := range mb.builders {
-		if strings.Contains(b.Logger.Output().(*bytes.Buffer).String(), fmt.Sprintf("Pulling %q", imageName)) {
+		if strings.Contains(b.Config().Globals.Logger.Output().(*bytes.Buffer).String(), fmt.Sprintf("Pulling %q", imageName)) {
 			if found {
 				c.Fatal("Found two pulls")
 			}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/box-builder/box/builder"
+	"github.com/box-builder/box/global"
 	"github.com/box-builder/box/logger"
 	"github.com/box-builder/box/signal"
 	"github.com/chzyer/readline"
@@ -38,12 +39,14 @@ func NewRepl(omit []string, log *logger.Logger) (*Repl, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	b, err := builder.NewBuilder(builder.BuildConfig{
-		OmitFuncs: omit,
-		TTY:       true,
-		Cache:     false,
-		Context:   ctx,
-		ShowRun:   true,
-		Logger:    log,
+		Globals: &global.Global{
+			OmitFuncs: omit,
+			TTY:       true,
+			Cache:     false,
+			ShowRun:   true,
+			Logger:    log,
+		},
+		Context: ctx,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Previously these parameters were all passed on the stack causing a ton
of idiocy in the API. This simplifies the code and works towards a more
abstract design for the builder.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>