### PR TITLE
Build system fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ test-ci: checks build-ci run-test-ci rmi
 test: checks all build run-test rmi
 
 release: clean all test
-	VERSION=${VERSION} RELEASE=1 go run main.go -n -t box-builder/box:${VERSION} build.rb
+	VERSION=${VERSION} RELEASE=1 go run main.go -n -t boxbuilder/box:${VERSION} build.rb
 	docker rm -f box-build-${VERSION} || :
-	docker run --name box-build-${VERSION} --entrypoint /bin/bash box-builder/box:${VERSION} -c 'exit 0'
+	docker run --name box-build-${VERSION} --entrypoint /bin/bash boxbuilder/box:${VERSION} -c 'exit 0'
 	docker cp box-build-${VERSION}:/box .
 	docker rm box-build-${VERSION}
 	sh release/release.sh ${VERSION}

--- a/build.rb
+++ b/build.rb
@@ -68,7 +68,7 @@ skip do
 
   workdir "/go/src/github.com/box-builder/box"
   set_exec entrypoint: ["/dind"], cmd: %w[make docker-test]
-  tag "box-test"
+  tag "box-test-"+getenv("SUM")
 end
 
 run "mv /go/bin/box /box"

--- a/build.rb
+++ b/build.rb
@@ -1,6 +1,6 @@
 from "debian"
 
-after { tag "box-builder/box:master" }
+after { tag "boxbuilder/box:master" }
 DOCKER_VERSION = "1.13.1"
 GOLANG_VERSION = "1.7.5"
 LVM2_VERSION = "2.02.103"

--- a/build.rb
+++ b/build.rb
@@ -68,7 +68,11 @@ skip do
 
   workdir "/go/src/github.com/box-builder/box"
   set_exec entrypoint: ["/dind"], cmd: %w[make docker-test]
-  tag "box-test-"+getenv("SUM")
+  sum = getenv("SUM")
+  if sum != ""
+    sum = "-#{sum}"
+  end
+  tag "box-test#{sum}"
 end
 
 run "mv /go/bin/box /box"

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -415,7 +415,7 @@ func (bs *builderSuite) TestTag(c *C) {
 	inspect, _, err := dockerClient.ImageInspectWithRaw(context.Background(), "test")
 	c.Assert(err, IsNil)
 
-	c.Assert(inspect.RepoTags, DeepEquals, []string{"debian:latest", "test:latest"})
+	c.Assert(inspect.RepoTags, DeepEquals, []string{"test:latest"})
 	b.Close()
 }
 

--- a/builder/command/commands.go
+++ b/builder/command/commands.go
@@ -6,11 +6,6 @@
 //
 package command
 
-/*
-TODO:
-flatten
-*/
-
 import (
 	"github.com/box-builder/box/builder/executor"
 	"github.com/box-builder/box/types"

--- a/builder/command/verbs.go
+++ b/builder/command/verbs.go
@@ -63,6 +63,9 @@ func (i *Interpreter) User(username string) error {
 
 // Tag is the `tag` verb.
 func (i *Interpreter) Tag(name string) error {
+	if err := i.exec.Commit("", nil); err != nil {
+		return err
+	}
 	return i.exec.Image().Tag(name)
 }
 


### PR DESCRIPTION
This improves the build system. It also contains a fix for a situation where tagging in an after block with skip statements, would not appropriately tag the image for use.