### PR TITLE
build.rb: bump Go to 1.8.1

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -6,7 +6,7 @@ after do
 end
 
 DOCKER_VERSION = "1.13.1"
-GOLANG_VERSION = "1.7.5"
+GOLANG_VERSION = "1.8.1"
 
 PACKAGES = %w[
   build-essential


### PR DESCRIPTION
This bumps Go to 1.8.1. This version addresses the issues discovered in 1.8.0.

https://github.com/golang/go/issues?q=is%3Aissue+milestone%3AGo1.8.1+is%3Aclosed