### PR TITLE
docs-theme: Remove container-header (for now)

### DIFF
--- a/docs-theme/container-header.html
+++ b/docs-theme/container-header.html
@@ -1,8 +1,0 @@
-<div class="container-header">
-    <div class="col-md-9 col-md-offset-3" role="main">
-	<div class="new-changes-title">Box ver.2.0.5 released !</div>
-	<p>Find out what's new here</p>
-    </div>
-
-	<div class="container-header-footer">updated 3/23/2017</div>
-</div>


### PR DESCRIPTION
This needs some additional tooling in the release.sh script that requires a markdown rendered for the changelog, which will require some styles.

I don't have time to do that just yet, so here's a patch to blank it out for now.