### PR TITLE
fix: box.rb as default filename

### DIFF
--- a/cli-tests/basic_test.go
+++ b/cli-tests/basic_test.go
@@ -1,13 +1,39 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/rendon/testcli"
 
 	. "gopkg.in/check.v1"
 )
+
+func (s *cliSuite) TestCanonicalFile(c *C) {
+	cmd := testcli.Command("box")
+	cmd.Run()
+	c.Assert(strings.Contains(cmd.Stdout(), "USAGE:"), Equals, true)
+
+	tmpPath := filepath.Join(os.TempDir(), "boxtest")
+	contents := []byte("from 'debian'\ntag 'boxrbtest'\n")
+	err := os.Mkdir(tmpPath, 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(tmpPath, "/box.rb"), contents, 0644)
+	c.Assert(err, IsNil)
+	cwd, oserr := os.Getwd()
+	c.Assert(oserr, IsNil)
+	os.Chdir(tmpPath)
+
+	cmd = testcli.Command("box")
+	cmd.Run()
+	c.Assert(strings.Contains(cmd.Stdout(), "Tagged: boxrbtest"), Equals, true, Commentf("%s", cmd.Stdout()))
+
+	// cleanup
+	os.Chdir(cwd)
+	os.RemoveAll(tmpPath)
+}
 
 func (s *cliSuite) TestBasic(c *C) {
 	cmd, err := build("", "test.rb")

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,10 +52,13 @@ Exploit this! Use functions! Set variables and constants!
 run this plan with:
 
 ```shell
-GOLANG_VERSION=1.7.5 box <plan file>
+GOLANG_VERSION=1.7.5 box [plan file]
 ```
 
+If a plan name is not specified it will default to `box.rb`.
+
 ```ruby
+# box.rb
 from "ubuntu"
 
 # this function will create a new layer running the command inside the

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var (
 	// Copyright is the copyright, generated automatically for each year.
 	Copyright = fmt.Sprintf("(C) %d %s - Licensed under MIT license", time.Now().Year(), Author)
 	// UsageText is the description of how to use the program.
-	UsageText = "box [options] filename"
+	UsageText = "box [options] [filename|box.rb]"
 )
 
 func main() {
@@ -121,6 +121,8 @@ func main() {
 
 		args := ctx.Args()
 
+		filename := detectFile(ctx)
+
 		if len(args) < 1 {
 			cli.ShowAppHelp(ctx)
 			log.Error("Please provide a filename to process!")
@@ -160,7 +162,7 @@ func main() {
 				Context:   cancelCtx,
 			},
 			Runner:   runChan,
-			FileName: args[0],
+			FileName: filename,
 		}
 
 		b, err := mkBuilder(cancel, buildConfig)
@@ -283,4 +285,16 @@ func mkBuilder(cancel context.CancelFunc, buildConfig builder.BuildConfig) (*bui
 	signal.Handler.AddFunc(cancel)
 	signal.Handler.AddRunner(buildConfig.Runner)
 	return b, nil
+}
+
+func detectFile(c *cli.Context) string {
+	a := c.Args()
+	if len(a) < 1 {
+		if _, err := os.Stat("box.rb"); os.IsNotExist(err) {
+			cli.ShowAppHelp(c)
+			os.Exit(0)
+		}
+		return "box.rb"
+	}
+	return a[0]
 }


### PR DESCRIPTION
This closes #203.
This closes #194.

`box.rb` is now the canonical filename for build plans. This changeset includes documentation updates.