### PR TITLE
buidler,fetcher,layers: fix cmd/entrypoint semantics

### DIFF
--- a/builder/command/from.go
+++ b/builder/command/from.go
@@ -40,7 +40,7 @@ func (i *Interpreter) From(image string) error {
 
 	if pulling {
 		<-pullChan
-		id, err = i.exec.Layers().Lookup(image)
+		id, err = i.exec.Layers().Lookup(i.exec.Config(), image)
 		if err != nil {
 			return err
 		}

--- a/builder/config/config.go
+++ b/builder/config/config.go
@@ -70,8 +70,23 @@ func (c *Config) ToDocker(temporary, tty, stdin bool) *container.Config {
 		user = c.User.Image
 	}
 
-	if cmd == nil && entrypoint == nil {
+	if len(entrypoint) == 0 && !temporary {
+		entrypoint = []string{}
+	}
+
+	if len(cmd) == 0 && !temporary {
+		cmd = []string{}
+	}
+
+	if len(cmd) == 0 && len(entrypoint) == 0 {
 		cmd = []string{"/bin/sh"}
+	}
+
+	if !temporary {
+		c.Entrypoint.Image = entrypoint
+		c.Entrypoint.Temporary = entrypoint
+		c.Cmd.Temporary = cmd
+		c.Cmd.Image = cmd
 	}
 
 	return &container.Config{
@@ -91,11 +106,17 @@ func (c *Config) ToDocker(temporary, tty, stdin bool) *container.Config {
 }
 
 // FromDocker sets *Config properties from a docker *container.Config
-func (c *Config) FromDocker(cont *container.Config) {
+func (c *Config) FromDocker(temporary bool, cont *container.Config) {
 	c.Image = cont.Image
 	c.Env = cont.Env
-	c.Entrypoint.Image = cont.Entrypoint
-	c.Cmd.Image = cont.Cmd
+	c.Entrypoint.Temporary = cont.Entrypoint
+	c.Cmd.Temporary = cont.Cmd
+
+	if !temporary {
+		c.Entrypoint.Image = cont.Entrypoint
+		c.Cmd.Image = cont.Cmd
+	}
+
 	c.User.Image = cont.User
 	c.WorkDir.Image = cont.WorkingDir
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -63,7 +63,7 @@ func Docker(context context.Context, globals *btypes.Global, client *client.Clie
 		}
 	}
 
-	config.FromDocker(inspect.Config)
+	config.FromDocker(false, inspect.Config)
 	config.Image = inspect.ID
 
 	return inspect.ID, inspect.RootFS.Layers, nil

--- a/layers/docker.go
+++ b/layers/docker.go
@@ -123,11 +123,13 @@ func (d *Docker) calculateCommits(layers []*image.Layer) []*image.Layer {
 }
 
 // Lookup an image by name, returning the id.
-func (d *Docker) Lookup(name string) (string, error) {
+func (d *Docker) Lookup(config *config.Config, name string) (string, error) {
 	img, _, err := d.client.ImageInspectWithRaw(d.globals.Context, name)
 	if err != nil {
 		return "", err
 	}
+
+	config.FromDocker(false, img.Config)
 
 	return img.ID, nil
 }

--- a/layers/docker_image.go
+++ b/layers/docker_image.go
@@ -212,7 +212,7 @@ func (d *DockerImage) CheckCache(cacheKey string) (bool, error) {
 
 			if inspect.Comment == cacheKey {
 				d.imageConfig.Globals.Logger.CacheHit(img.ID)
-				d.imageConfig.Config.FromDocker(inspect.Config)
+				d.imageConfig.Config.FromDocker(true, inspect.Config)
 				d.imageConfig.Config.Image = img.ID
 				return true, d.imageConfig.Layers.AddImage(img.ID)
 			}

--- a/layers/docker_test.go
+++ b/layers/docker_test.go
@@ -71,7 +71,7 @@ func (ds *dockerSuite) TestLookup(c *C) {
 	// XXX ok if this call fails
 	d.client.ImageRemove(d.globals.Context, imageName, types.ImageRemoveOptions{PruneChildren: true, Force: true})
 
-	id, err := d.Lookup(imageName)
+	id, err := d.Lookup(ds.config, imageName)
 	c.Assert(err, NotNil)
 	c.Assert(id, Equals, "")
 
@@ -79,7 +79,7 @@ func (ds *dockerSuite) TestLookup(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(origid, Not(Equals), "")
 
-	newid, err := d.Lookup(imageName)
+	newid, err := d.Lookup(ds.config, imageName)
 	c.Assert(err, IsNil)
 	c.Assert(newid, Equals, origid)
 }

--- a/layers/types.go
+++ b/layers/types.go
@@ -50,7 +50,7 @@ type Layers interface {
 	MakeImage(config *config.Config) (string, error)
 
 	// Look up an image identifier.
-	Lookup(string) (string, error)
+	Lookup(*config.Config, string) (string, error)
 }
 
 // ImageConfig sets the properties used to construct an image


### PR DESCRIPTION
previously, nulls would be set on the entrypoint, triggering inheritance
from `run` statments that were the previous commit in the docker chain.
What this does now is set it to `[]string` which is an empty command in
the docker configuration.

Note that there is now no way to do `entrypoint nil` in a way that will
inherit from the previous entrypoint statement, however, I don't think
this is necessarily a bad thing. :)

Fixes #232

Signed-off-by: Erik Hollensbe <github@hollensbe.org>