### PR TITLE
portable.sh.tmpl: bring in environment variables from the host

### DIFF
--- a/portable.sh.tmpl
+++ b/portable.sh.tmpl
@@ -1,3 +1,13 @@
 #!/bin/sh
 
-exec docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:$PWD -w $PWD boxbuilder/box:@@VERSION@@ $*
+dockerenv=""
+
+if [ "x${BOX_INCLUDE_ENV}" != "x" ]
+then
+  for e in ${BOX_INCLUDE_ENV}
+  do
+    dockerenv="${dockerenv} -e $(printf "${e}=$(eval printf '%s' $$e)")"
+  done
+fi
+
+exec docker run --rm -it ${dockerenv} -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:$PWD -w $PWD boxbuilder/box:@@VERSION@@ $*


### PR DESCRIPTION
Previously, if the user specified environment variables, they were
ignored by the portable script. This is because the environment
variables would need to have been propagated to docker that box runs in,
so it can then read the environment variables from the container.

Now, you can specify BOX_INCLUDE_ENV to whitespace-delimit environment
variables to pass from your host into the container, allowing it to be
easy to generically do this in make tasks etc.

This is a stop-gap for environment usage on OS X in particular, until
0.6.0 arrives (with real dictionaries) this feature is really
needed.

This will be backported into 0.5.4.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>