### PR TITLE
added tests for --var

### DIFF
--- a/cli-tests/basic_test.go
+++ b/cli-tests/basic_test.go
@@ -15,6 +15,27 @@ func (s *cliSuite) TestBasic(c *C) {
 	cmd, err := build("", "test.rb")
 	c.Assert(err, IsNil)
 	checkSuccess(c, cmd)
+
+}
+
+func (s *cliSuite) TestVar(c *C) {
+	cmd, err := build(`
+	   from "alpine"
+		 run "echo #{getvar("testvar)}"
+	`, "--var testvar=test")
+	c.Assert(err, IsNil)
+	checkSuccess(c, cmd)
+
+	c.Assert(strings.Contains(cmd.Stdout(), "test"), Equals, true, Commentf("%s", cmd.Stdout()))
+
+	cmd, err = build(`
+	   from "alpine"
+		 run "echo #{getvar("testvar)}"
+	`)
+	c.Assert(err, IsNil)
+	checkSuccess(c, cmd)
+
+	c.Assert(strings.Contains(cmd.Stdout(), "test"), Equals, false, Commentf("%", cmd.Stdout()))
 }
 
 func (s *cliSuite) TestCache(c *C) {


### PR DESCRIPTION
Added basic testing for the --var command line switch.  

Steps: 

1. create an ad-hoc box file that prints out the variable defined by --var
2. check stdout to make sure the variable expected is printed out
3. run another test with an ad-hoc box file that doesn't print the variable value to stdout and doesn't pass in said variable to --var
4. check stdout to make sure there is no variable printed