### PR TITLE
box.rb: bump Go to 1.8.5

### DIFF
--- a/box.rb
+++ b/box.rb
@@ -6,7 +6,7 @@ after do
 end
 
 DOCKER_VERSION = "1.13.1"
-GOLANG_VERSION = "1.8.3"
+GOLANG_VERSION = "1.8.5"
 
 PACKAGES = %w[
   build-essential


### PR DESCRIPTION
This bumps  Go to 1.8.4 to fix the RCE vulnerability in `go get`.
https://github.com/golang/go/issues?q=milestone%3AGo1.8.4