### PR TITLE
Move to golang 1.9.2

### DIFF
--- a/box.rb
+++ b/box.rb
@@ -6,7 +6,7 @@ after do
 end
 
 DOCKER_VERSION = "1.13.1"
-GOLANG_VERSION = "1.8.3"
+GOLANG_VERSION = "1.9.2"
 
 PACKAGES = %w[
   build-essential


### PR DESCRIPTION
This moves the build environment to golang 1.9.2.
