### PR TITLE
box mac version report `the input device is not a TTY`

### DIFF
--- a/portable.sh.tmpl
+++ b/portable.sh.tmpl
@@ -2,6 +2,11 @@
 
 dockerenv=""
 
+if [ $(tty -s; echo $?) -eq 0 ]
+then
+    dockerenv="-it"
+fi
+
 if [ "x${BOX_INCLUDE_ENV}" != "x" ]
 then
   for e in ${BOX_INCLUDE_ENV}
@@ -10,4 +15,4 @@ then
   done
 fi
 
-exec docker run --rm -it ${dockerenv} -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:$PWD -w $PWD boxbuilder/box:@@VERSION@@ $*
+exec docker run --rm ${dockerenv} -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:$PWD -w $PWD boxbuilder/box:@@VERSION@@ $*


### PR DESCRIPTION
Reproduce codes:
```
func main() {
    cmd := exec.CommandContext(context.Background(), "box", "-o", "tag", "-n", "-t", "test123", "./box.rb")

    out, err := cmd.CombinedOutput()
    fmt.Println(err)
    fmt.Println(string(out))
}
```

Signed-off-by: Leslie Qi Wang <leslie.qiwa@gmail.com>